### PR TITLE
Add support for the sway compositor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Kitti3 - Kitty drop-down manager for i3wm
+# Kitti3 - Kitty drop-down manager for i3 & Sway
 Kitti3 turns [Kitty](https://sw.kovidgoyal.net/kitty/) into a drop-down, Quake-style 
-floating terminal for the [i3 window manager](https://i3wm.org/).
+floating terminal for the [i3](https://i3wm.org/) and [Sway](https://swaywm.org/) window
+managers.
 
 #### Features
-- i3wm native, *flicker-free* visibility toggling 
-- Multi-monitor support with adaptive resizing to active monitor resolution
+- i3 & Sway native, *flicker-free* visibility toggling 
+- Multi-monitor support with adaptive resizing and alignment to the active monitor
 - Flexible choice of terminal position; freely selectable dimensions
-- Great responsiveness by leveraging i3wm's IPC API
+- Great responsiveness by leveraging the i3/Sway IPC API
 - Support for multiple concurrent instances
 - Kitty argument forwarding (e.g. `--session`)
 
@@ -28,10 +29,10 @@ Kitti3 is a Python 3 package that [lives on PYPI](https://pypi.org/project/kitti
     to somewhere on your $PATH, rename it to `kitti3` and make it executable. *(Note:
     in this case it's your responsibility to satisfy the Python [dependencies](#dependencies))* 
 
-2. Ensure that Kitti3 is reachable (e.g. `$ which kitti3`); i3wm won't necessarily complain later 
+2. Ensure that Kitti3 is reachable (e.g. `$ which kitti3`); the WM won't necessarily complain later 
 if it isn't!
 
-3. Add the following to your `~/.config/i3/config`:
+3. Add the following to your `~/.config/<WM>/config`:
     ```commandline
     exec_always --no-startup-id kitti3
     bindsym $mod+n nop kitti3
@@ -40,7 +41,7 @@ if it isn't!
     [configuration](#configuration) section below for a list of the CLI options that
     `kitti3` accepts.
     
-4. Restart i3wm inplace (e.g. `$mod+Shift+r`)
+4. Restart i3/Sway inplace (e.g. `$mod+Shift+r`)
 
 5. Trigger the shortcut to verify that the terminal appears (slight flicker / tiling 
 noise is normal on the first toggle when Kitty is spawned and floated by Kitti3)
@@ -54,13 +55,13 @@ $ kitti3 -h
 usage: kitti3 [-h] [-n NAME] [-p {LT,LC,LB,CT,CC,CB,RT,RC,RB}]
               [-s SHAPE SHAPE] [-v]
 
-Kitti3: i3wm drop-down manager for Kitty. Arguments following '--' are
+Kitti3: i3/Sway drop-down manager for Kitty. Arguments following '--' are
 forwarded to the Kitty instance
 
 optional arguments:
   -h, --help            show this help message and exit
   -n NAME, --name NAME  name/tag used to identify this Kitti3 instance. Must
-                        match the keybinding used in the i3wm config (e.g.
+                        match the keybinding used in the i3/Sway config (e.g.
                         `bindsym $mod+n nop NAME`)
   -p {LT,LC,LB,CT,CC,CB,RT,RC,RB}, --position {LT,LC,LB,CT,CC,CB,RT,RC,RB}
                         where to position the Kitty window within the active
@@ -74,10 +75,10 @@ optional arguments:
 ```
 ### Command line options
 #### `-n, --name` (default: `kitti3`)
-The name option provides the string identifier used to connect a user-defined i3wm 
-keybinding to the Kitti3 instance. Specifically, Kitti3 will listen to i3wm IPC events
+The name option provides the string identifier used to connect a user-defined i3/Sway 
+keybinding to the Kitti3 instance. Specifically, Kitti3 will listen to IPC events
 and toggle the visibility of Kitty when it encounters the bindsym command `nop NAME` - 
-hence the requirement to include a "no-op" bindsym declaration in your i3wm config.
+hence the requirement to include a "no-op" bindsym declaration in your config.
 
 The name option value is also used internally to associate Kitti3 with the Kitty 
 instance it manages (the latter is forwarded the argument `--name NAME`). For this
@@ -121,7 +122,7 @@ when position is set to `left` or `right`.
 
 ### Examples
 #### Centered terminal with custom name and argument forwarding
-The following i3wm configuration snippet produces a Kitty terminal positioned at the 
+The following i3/Sway configuration snippet produces a Kitty terminal positioned at the 
 center of the workspace, filling half its height and 30% of its width. It is assigned 
 the custom name "caterwaul", and the argument `--session ~/.kitty_session` is forwarded
 to Kitty when it is spawned.
@@ -143,15 +144,15 @@ bindsym $mod+b nop bubblegum
 ```
 
 ### Updating the configuration
-Kitti3 must be respawned to trigger any changes made to its command line arguments in the
-i3wm config file. This can most easily be achieved by restarting i3wm inplace (e.g. 
-`$mod+Shift+r`), which because of the use of `exec_always` will spawn a new instance
-of Kitti3. The old instance will automatically exit when it detects a restart event, so
-you should not see any stray instances hanging around.
+Kitti3 must be respawned to trigger any changes made to its command line arguments in 
+the i3/Sway config file. This can most easily be achieved by restarting the WM inplace 
+(e.g. `$mod+Shift+r`), which because of the use of `exec_always` will spawn a new 
+instance of Kitti3. The old instance will automatically exit when it detects a restart 
+event, so you should not see any stray instances hanging around.
 
 ## Dependencies
 - [Kitty](https://sw.kovidgoyal.net/kitty/) (duh)
-- i3wm (tested with 4.19 but if you're stuck in the past should be fine on 3.xx)
+- i3 > 4 or Sway >= 1.6 (you should also be fine on the latest git)
 - Python >= 3.6 
 - [i3ipc-python](https://github.com/altdesktop/i3ipc-python) (pip(x) will pull in >=2.0)
 
@@ -184,18 +185,19 @@ behaviour when spawning terminals. If you're open to using other terminals than 
 i3-quickterm's inability to display terminals as slide-ins (as opposed to drop-down or 
 pop-up) that prompted the creation of Kitti3.
  
-Kitti3 runs as a daemon and listens to events through i3wm's IPC API, using information
-about the active workspace to dynamically direct i3wm in how to best resize and position 
-Kitty when visibility is toggled. This leads to excellent responsiveness and no flicker 
-artifacts, as well as a seamless experience in multi-monitor, multi-resolution setups.
+Kitti3 runs as a daemon and listens to events through the i3/Sway IPC API, using 
+information about the active workspace to dynamically direct the WM in how to best 
+resize and position Kitty when visibility is toggled. This leads to excellent 
+responsiveness and no flicker artifacts, as well as a seamless experience in 
+multi-monitor, multi-resolution setups.
 
-### Bare-metal i3wm config
+### Bare-metal i3/Sway config
 *"But I don't have a hundred external monitors on my desk!"* you cry out. Well, if you're
 running a single-monitor setup, or you're simply content with having the terminal 
 displayed on your main monitor only, then you don't actually need Kitti3 or any of the 
-other bolt-ons. i3wm is happy to take care of container floating and positioning if 
+other bolt-ons. The WM is happy to take care of container floating and positioning if 
 you're happy to work with absolute pixel values. This is where you start (add to 
-`~/.config/i3/config`):
+`~/.config/<WM>/config`):
 ```commandline
 exec --no-startup-id kitty --name dropdown 
 for_window [instance="dropdown"] floating enable, border none, move absolute \

--- a/src/kitti3/main.py
+++ b/src/kitti3/main.py
@@ -301,7 +301,7 @@ def _simple_fraction(arg: str) -> float:
 def _parse_args(argv: List[str], defaults: dict) -> argparse.Namespace:
     ap = argparse.ArgumentParser(
         description=(
-            "Kitti3: i3wm drop-down manager for Kitty. Arguments following '--' are"
+            "Kitti3: i3/Sway drop-down manager for Kitty. Arguments following '--' are"
             " forwarded to the Kitty instance"
         )
     )
@@ -311,7 +311,7 @@ def _parse_args(argv: List[str], defaults: dict) -> argparse.Namespace:
         "--name",
         help=(
             "name/tag used to identify this Kitti3 instance. Must match the keybinding"
-            " used in the i3wm config (e.g. `bindsym $mod+n nop NAME`)"
+            " used in the i3/Sway config (e.g. `bindsym $mod+n nop NAME`)"
         ),
     )
     ap.add_argument(

--- a/src/kitti3/main.py
+++ b/src/kitti3/main.py
@@ -2,8 +2,11 @@
 
 import argparse
 import enum
+import functools
 import sys
-from typing import Tuple, List, Optional
+import time
+from collections import namedtuple
+from typing import List, Optional, Tuple
 
 import i3ipc
 
@@ -17,6 +20,19 @@ DEFAULTS = {
     "name": "kitti3",
     "shape": (1.0, 0.4),
     "position": "RIGHT",
+}
+
+CLIENTS = {
+    "kitty": {
+        "i3": {
+            "cmd": "--no-startup-id kitty --name {}",
+            "crit_attr": "window_instance",
+        },
+        "sway": {
+            "cmd": "kitty --class {}",
+            "crit_attr": "app_id",
+        },
+    },
 }
 
 
@@ -57,34 +73,57 @@ class Position(enum.Enum):
 
 
 class Shape:
-    def __init__(self, x, y):
+    def __init__(self, x: float, y: float):
         if max(x, y) > 1.0 or min(x, y) < 0.0:
             raise ValueError(f"shape out of range [0,1]: x={x}, y={y}")
-        self.x = x
-        self.y = y
+        self.x: float = x
+        self.y: float = y
 
 
-class Kitti3:
-    def __init__(self, name: str, shape: Shape, pos: Position, kitty_argv: list = None):
+Client = namedtuple("Client", ["cmd", "crit_attr"])
+
+
+class Trigger(enum.Enum):
+    KEYBIND = enum.auto()
+    SPAWNED = enum.auto()
+    FLOATED = enum.auto()
+    MOVED = enum.auto()
+
+
+class Rect(namedtuple("Rect", ["x", "y", "w", "h"])):
+    __slots__ = ()
+
+    @classmethod
+    def from_i3ipc(cls, r: i3ipc.Rect):
+        return cls(r.x, r.y, r.width, r.height)
+
+
+class Kitt:
+    def __init__(
+        self,
+        conn: i3ipc.Connection,
+        name: str,
+        shape: Shape,
+        pos: Position,
+        client: Client,
+        client_argv: List[str] = None,
+    ):
+        self.i3 = conn
         self.name = name
         self.shape = shape
         self.pos = pos
-        self.kitty_argv = kitty_argv
+        self.client = client
+        self.client_argv = client_argv
 
-        self.con_id = None
-        self.con_ws = None
-        self.focused_ws = None
+        self.con_id: Optional[str] = None
+        self.con_ws: Optional[i3ipc.WorkspaceReply] = None
+        self.focused_ws: Optional[i3ipc.WorkspaceReply] = None
 
-        self.i3 = i3ipc.Connection()
         self.i3.on("binding", self.on_keybind)
         self.i3.on("window::new", self.on_spawned)
         self.i3.on("window::floating", self.on_floated)
         self.i3.on("window::move", self.on_moved)
         self.i3.on("shutdown::exit", self.on_shutdown)
-
-        # FIXME: half-baked way of checking what WM we're running on.
-        self.sway = "sway" in self.i3.socket_path or self.i3.get_version().major < 3
-        self.align_to_ws = self._align_to_ws_sway if self.sway else self._align_to_ws_i3
 
     def loop(self) -> None:
         """Enter listening mode, awaiting IPC events."""
@@ -109,7 +148,7 @@ class Kitti3:
         elif self.con_ws.name == self.focused_ws.name:
             self.i3.command(f"[con_id={self.con_id}] floating enable, move scratchpad")
         else:
-            self.align_to_ws(fetch=True)
+            self.align_to_ws(Trigger.KEYBIND)
 
     def on_spawned(self, _, we: i3ipc.WindowEvent) -> None:
         """Float the Kitty window once it has settled after spawning.
@@ -118,11 +157,11 @@ class Kitti3:
         alignment.
         """
         con = we.container
-        if self.name not in (con.window_instance, con.app_id):
+        if getattr(con, self.client.crit_attr) != self.name:
             return
         self.con_id = con.id
         self._refresh()
-        self.i3.command(f"[con_id={self.con_id}] floating enable, border none")
+        self.align_to_ws(Trigger.SPAWNED)
 
     def on_floated(self, _, we: i3ipc.WindowEvent) -> None:
         """Ensure that the Kitty window is aligned to its workspace when transitioning
@@ -140,7 +179,7 @@ class Kitti3:
         # despawn guard + toggle-while-tiled trigger repression
         if self.con_ws is None or self.con_ws.name == "__i3_scratch":
             return
-        self.align_to_ws(fetch=False)
+        self.align_to_ws(Trigger.FLOATED)
 
     def on_moved(self, _, we: i3ipc.WindowEvent) -> None:
         """Ensure that the Kitty window is positioned and resized when moved to a
@@ -149,8 +188,7 @@ class Kitti3:
         If Kitty has been manually tiled by the user it will not be re-floated.
         """
         con = we.container
-        # skip if sway until compatibility issue is resolved
-        if self.sway or not (
+        if not (
             # ignore tiled cons
             con.type == "floating_con"
             # event's con is floating wrapper for i3, but target con for sway
@@ -167,89 +205,50 @@ class Kitti3:
             or self.con_ws.name == "__i3_scratch"
         ):
             return
-        self.align_to_ws(fetch=False)
+        self.align_to_ws(Trigger.MOVED)
 
     @staticmethod
     def on_shutdown(_, se: i3ipc.ShutdownEvent):
         exit(0)
 
     def spawn(self) -> None:
-        """Spawn a new Kitty window associated with the name of this Kitti3 instance."""
-        arg = "class" if self.sway else "name"
-        cmd_base = f"exec --no-startup-id kitty --{arg} {self.name}"
-        if self.kitty_argv is None:
-            cmd = cmd_base
-        else:
-            argv = " ".join(self.kitty_argv)
-            cmd = f"{cmd_base} {argv}"
+        """Spawn a new client window associated with the name of this Kitti3 instance."""
+        cmd = f"exec {self.client.cmd.format(self.name)}"
+        if self.client_argv:
+            cmd = f"{cmd} {' '.join(self.client_argv)}"
         self.i3.command(cmd)
 
-    def _align_to_ws_i3(self, fetch: bool = True) -> None:
-        """Adapt the dimensions and location of Kitty's window to the `ws` workspace.
-
-        If `fetch` is True, Kitty will be moved from its current workspace to the
-        focused workspace via the scratchpad (where it might already reside).
-
-        TODO:
-            - We can skip alignment if src and dest WSs are on the same output, and
-              kitty has not gone from tiled to floating (i.e. this method was not called
-              from `on_float()`). However, it's probably not worth the hassle to track.
-        """
-        if self.con_id is None:
-            raise RuntimeError("internal error: Kitty instance ID not yet assigned")
-        ws = self.focused_ws if fetch else self.con_ws
-        width = round(ws.rect.width * self.shape.x)
-        height = round(ws.rect.height * self.shape.y)
-        x = {
-            "L": ws.rect.x,
-            "C": ws.rect.x + round((ws.rect.width / 2) - (width / 2)),
-            "R": ws.rect.x + ws.rect.width - width,
-        }[self.pos.x]
-        y = {
-            "T": ws.rect.y,
-            "C": ws.rect.y + round((ws.rect.height / 2) - (height / 2)),
-            "B": ws.rect.y + ws.rect.height - height,
-        }[self.pos.y]
-
-        self.i3.command(
-            f"[con_id={self.con_id}]"
-            f"{f' move container to workspace {ws.name},' if fetch else ''}"
-            f" resize set {width}px {height}px,"
-            f" move absolute position {x}px {y}px,"
-            f"{ 'focus' if fetch else ''}"
-        )
-
-    def _align_to_ws_sway(self, fetch: bool = True) -> None:
-        """Adapt the dimensions and location of Kitty's window to the `ws` workspace.
-
-        If `fetch` is True, Kitty will be moved from its current workspace to the
-        focused workspace.
-        """
-        if self.con_id is None:
-            raise RuntimeError("internal error: Kitty instance ID not yet assigned")
-        ws = self.focused_ws if fetch else self.con_ws
-
-        width = round(self.shape.x * 100)
-        height = round(self.shape.y * 100)
-
-        x = {
-            "L": 0,
-            "C": round(50 - (width / 2)),
-            "R": 100 - width,
-        }[self.pos.x]
-        y = {
-            "T": 0,
-            "C": round(50 - (height / 2)),
-            "B": 100 - height,
-        }[self.pos.y]
-
-        self.i3.command(
-            f"[con_id={self.con_id}]"
-            f"{f' move container to workspace {ws.name},' if fetch else ''}"
-            f" resize set {width}ppt {height}ppt,"
-            f" move position {x}ppt {y}ppt,"
-            f"{ 'focus' if fetch else ''}"
-        )
+    @functools.lru_cache()
+    def con_rect(self, abs_ref: Rect = None) -> Rect:
+        # relative/ppt
+        if abs_ref is None:
+            width = round(self.shape.x * 100)
+            height = round(self.shape.y * 100)
+            x = {
+                "L": 0,
+                "C": round(50 - (width / 2)),
+                "R": 100 - width,
+            }[self.pos.x]
+            y = {
+                "T": 0,
+                "C": round(50 - (height / 2)),
+                "B": 100 - height,
+            }[self.pos.y]
+        # absolute/px
+        else:
+            width = round(abs_ref.w * self.shape.x)
+            height = round(abs_ref.h * self.shape.y)
+            x = {
+                "L": abs_ref.x,
+                "C": abs_ref.x + round((abs_ref.w / 2) - (width / 2)),
+                "R": abs_ref.x + abs_ref.w - width,
+            }[self.pos.x]
+            y = {
+                "T": abs_ref.y,
+                "C": abs_ref.y + round((abs_ref.h / 2) - (height / 2)),
+                "B": abs_ref.y + abs_ref.h - height,
+            }[self.pos.y]
+        return Rect(x, y, width, height)
 
     def _refresh(self) -> None:
         """Update the information on the presence of the associated Kitty instance,
@@ -258,7 +257,7 @@ class Kitti3:
         tree = self.i3.get_tree()
         if self.con_id is None:
             for con in tree:
-                if self.name in (con.window_instance, con.app_id):
+                if getattr(con, self.client.crit_attr) == self.name:
                     self.con_id = con.id
                     self.con_ws = con.workspace()
                     break
@@ -280,6 +279,68 @@ class Kitti3:
         else:
             self.focused_ws = None
 
+    def align_to_ws(self, context: Trigger) -> None:
+        raise NotImplementedError
+
+
+class Kitts(Kitt):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sway_timing_compat = True  # TODO: add as arg
+
+    def on_moved(self, _, we: i3ipc.WindowEvent) -> None:
+        # Currently under Sway, if a container on an inactive workspace is resized, it
+        # is forcibly reparented to its output's active workspace. Therefore, this
+        # feature is diabled, pending https://github.com/swaywm/sway/issues/6465 .
+        return
+
+    def spawn(self) -> None:
+        r = self.con_rect()
+        self.i3.command(
+            f"for_window [app_id={self.name}] 'floating enable, border none, resize set"
+            f" {r.w}ppt {r.h}ppt, move position {r.x}ppt {r.y}ppt'"
+        )
+        super().spawn()
+
+    def align_to_ws(self, context: Trigger) -> None:
+        if context == Trigger.SPAWNED:
+            return
+        if context == Trigger.FLOATED and self.sway_timing_compat:
+            time.sleep(0.02)
+        r = self.con_rect()
+        crit = f"[con_id={self.con_id}]"
+        resize = f"resize set {r.w}ppt {r.h}ppt"
+        move = f"move position {r.x}ppt {r.y}ppt"
+        if context == Trigger.KEYBIND:
+            fetch = f"move container to workspace {self.focused_ws.name}"
+            cmd = f"{crit} {fetch}, {resize}, {move}, focus"
+        else:
+            cmd = f"{crit} {resize}, {move}"
+        self.i3.command(cmd)
+
+
+class Kitti3(Kitt):
+    def align_to_ws(self, context: Trigger) -> None:
+        # Under i3, in multi-output configurations, a ppt move is considered relative
+        # to the rect defined by the bounding box of all outputs, not by the con's
+        # workspace. Yes, this is madness, and so we have to do absolute moves (and
+        # therefore we also do absolute resizes to stay consistent).
+        if context == Trigger.SPAWNED:
+            # floating will trigger on_floated to do the actual alignment
+            self.i3.command(f"[con_id={self.con_id}] floating enable, border none")
+            return
+        ws = self.focused_ws if context == Trigger.KEYBIND else self.con_ws
+        r = self.con_rect(Rect.from_i3ipc(ws.rect))
+        crit = f"[con_id={self.con_id}]"
+        resize = f"resize set {r.w}px {r.h}px"
+        move = f"move absolute position {r.x}px {r.y}px"
+        if context == Trigger.KEYBIND:
+            fetch = f"move container to workspace {ws.name}"
+            cmd = f"{crit} {fetch}, {resize}, {move}, focus"
+        else:
+            cmd = f"{crit} {resize}, {move}"
+        self.i3.command(cmd)
+
 
 def _split_args(args: List[str]) -> Tuple[List, Optional[List]]:
     try:
@@ -294,7 +355,7 @@ def _simple_fraction(arg: str) -> float:
     if not 0 <= arg <= 1:
         raise argparse.ArgumentError(
             "argument must be a simple fraction, within [0, 1]"
-        )
+    )
     return arg
 
 
@@ -357,13 +418,27 @@ def _parse_args(argv: List[str], defaults: dict) -> argparse.Namespace:
 def cli() -> None:
     argv_kitti3, argv_kitty = _split_args(sys.argv[1:])
     args = _parse_args(argv_kitti3, DEFAULTS)
-    kitti3 = Kitti3(
+
+    conn = i3ipc.Connection()
+    # FIXME: half-baked way of checking what WM we're running on.
+    sway = "sway" in conn.socket_path or conn.get_version().major < 3
+    _Kitt = Kitts if sway else Kitti3
+    # TODO: add arg --client and --crit-attr:
+    #   - if client is single word, create Client from CLIENTS lookup,
+    #   - else ensure name placeholder in client and use w/--crit-attr to create Client
+    #   - client should default to 'kitty'
+    #   - crit-attr should default to window_instance for i3 and app_id for sway
+    client = Client(**CLIENTS["kitty"]["sway" if sway else "i3"])
+
+    kitt = _Kitt(
+        conn=conn,
         name=args.name,
         shape=args.shape,
         pos=args.position,
-        kitty_argv=argv_kitty,
+        client=client,
+        client_argv=argv_kitty,
     )
-    kitti3.loop()
+    kitt.loop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Feature parity
Kitti3 generally behaves as expected under sway, with the following remarks.
### Adherence to gaps
Under sway, if gaps are active for a client's workspace, these will be taken into acount when aligning. 
### Alignment on floated
As described in #17, an issue can occur when clients are resized twice within a short time frame (i.e. when floated, as sway will do a default resize before emitting the floating event which Kitti3 aligns on), leading to the discarding of the second instruction. A blanket 20ms delay in processing floating events has been introduced as a temporary measure until a better solution can be found.
### Alignment on moved
Currently under Sway, if a container on an inactive workspace is resized, it is forcibly reparented to its output's active workspace. Therefore, this feature is diabled, pending movement on swaywm/sway#6465 .

